### PR TITLE
syntax (interpolation) changes to support terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,17 +1,17 @@
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 }
 
 resource "aws_route_table" "public_to_internet" {
-  vpc_id = "${local.vpc_id}"
+  vpc_id = local.vpc_id
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${local.igw_id}"
+    gateway_id = local.igw_id
   }
 
-  tags {
+  tags = {
     Name    = "Internet access"
-    Project = "${local.project}"
+    Project = local.project
   }
 }


### PR DESCRIPTION
Most of the changes are related only to interpolation syntax (or to avoid errors in _tags_ attributes)